### PR TITLE
Drop texlive-backports PPA

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -201,7 +201,7 @@ BootstrapLinux() {
 BootstrapLinuxOptions() {
     if [[ -n "$BOOTSTRAP_LATEX" ]]; then
         # We add a backports PPA for more recent TeX packages.
-        sudo add-apt-repository -y "ppa:texlive-backports/ppa"
+        # sudo add-apt-repository -y "ppa:texlive-backports/ppa"
 
         Retry sudo apt-get install -y --no-install-recommends \
             texlive-base texlive-latex-base texlive-generic-recommended \


### PR DESCRIPTION
When `BOOTSTRAP_LATEX="true"` the original script gave the error:

    E: The repository 'http://ppa.launchpad.net/texlive-backports/ppa/ubuntu bionic Release' does not have a Release file.

Simply uncommenting the line that adds the PPA fixes the error in my case.